### PR TITLE
use null instead of ':not(*)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simply copy the following snippet into your page.
 
 <!-- prettier-ignore-start -->
 ```html
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||':not(*)')?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||null)?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/builder.html
+++ b/docs/builder.html
@@ -64,7 +64,7 @@
     <span class="code-comment">// Remove setTimeout to let the browser autoscroll content changes into view</span>
     setTimeout(() =></span>
     <span class="code-no-autoscroll">  </span>document
-    <span class="code-no-autoscroll">  </span>  .querySelector(frame.contentWindow.location.hash || ":not(*)")
+    <span class="code-no-autoscroll">  </span>  .querySelector(frame.contentWindow.location.hash || null)
     <span class="code-no-autoscroll">  </span>  ?.replaceWith(...frame.contentDocument.body.children)<span class="code-no-autoscroll">
     );</span>
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       <div>
         <h2>lightweight<span class="heading-icon">🪶</span></h2>
         <p>
-          <strong>181 bytes in total.</strong> Zero dependencies. Zero JS
+          <strong>176 bytes in total.</strong> Zero dependencies. Zero JS
           bundles to load. Not even a backend is required.
           <em>Just an inline HTML snippet</em>.
         </p>
@@ -115,7 +115,7 @@
       <p>Simply copy the following snippet into your page:</p>
       <pre
         class="code"
-      ><code class="rainbow-mask">&lt;iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||':not(*)')?.replaceWith(...this.contentDocument.body.childNodes))">&lt;/iframe></code></pre>
+      ><code class="rainbow-mask">&lt;iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||null)?.replaceWith(...this.contentDocument.body.childNodes))">&lt;/iframe></code></pre>
       <p>
         For <strong>npm enjoyers</strong>, the following npm commands automate
         the process of copying the snippet into your page:
@@ -371,7 +371,7 @@
     <span class="code-comment">// Remove setTimeout to let the browser autoscroll content changes into view</span>
     <span class="code-token">setTimeout</span>(() =>
       document
-        .<span class="code-token">querySelector</span>(frame.contentWindow.location.hash || <span class="code-template">":not(*)"</span>)
+        .<span class="code-token">querySelector</span>(frame.contentWindow.location.hash || <span class="code-template">null</span>)
         ?.<span class="code-token">replaceWith</span>(...frame.contentDocument.body.children)
     );
   }

--- a/examples/html_tabs/index.html
+++ b/examples/html_tabs/index.html
@@ -17,4 +17,4 @@
 
 <div id="my-tab-panel" role="tabpanel"></div>
 
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||':not(*)')?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||null)?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>

--- a/examples/js_simple_error_handling/index.html
+++ b/examples/js_simple_error_handling/index.html
@@ -39,7 +39,7 @@
 
     setTimeout(() =>
       document
-        .querySelector(frame.contentWindow.location.hash || ":not(*)")
+        .querySelector(frame.contentWindow.location.hash || null)
         ?.replaceWith(...frame.contentDocument.body.children)
     );
   }

--- a/examples/node_chat/index.html
+++ b/examples/node_chat/index.html
@@ -29,7 +29,7 @@
 </form>
 
 <!-- prettier-ignore -->
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||':not(*)')?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||null)?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>
 
 <style>
   body {

--- a/htmz.dev.html
+++ b/htmz.dev.html
@@ -5,7 +5,7 @@
     // Remove setTimeout to let the browser autoscroll content changes into view
     setTimeout(() =>
       document
-        .querySelector(frame.contentWindow.location.hash || ":not(*)")
+        .querySelector(frame.contentWindow.location.hash || null)
         ?.replaceWith(...frame.contentDocument.body.children)
     );
   }

--- a/htmz.html
+++ b/htmz.html
@@ -1,1 +1,1 @@
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||':not(*)')?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||null)?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>

--- a/npx/index.js
+++ b/npx/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const fs = require("node:fs");
 
-const htmzSnippet = `<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||':not(*)')?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>`;
+const htmzSnippet = `<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(this.contentWindow.location.hash||null)?.replaceWith(...this.contentDocument.body.childNodes))"></iframe>`;
 
 if (process.argv.length < 3 || process.argv.length > 3 || process.argv[2].startsWith("-")) {
   console.error(`\


### PR DESCRIPTION
thanks to HN commenters who suggested this.

The spec seems to allow it, but advises authors against it. https://www.w3.org/TR/selectors-api/#queryselector

> Implementers are advised that if null or undefined are passed as the value of the selectors parameter, they are to be handled as defined in WebIDL [[DOM-BINDINGS]](https://www.w3.org/TR/selectors-api/#DOM-BINDINGS). Authors are advised to avoid passing these values.