### PR TITLE
Enhance: removed unused `.this` for dev

### DIFF
--- a/htmz.dev.html
+++ b/htmz.dev.html
@@ -5,8 +5,8 @@
     // Remove setTimeout to let the browser autoscroll content changes into view
     setTimeout(() =>
       document
-        .querySelector(frame.contentWindow.location.hash || null)
-        ?.replaceWith(...frame.contentDocument.body.children)
+        .querySelector(contentWindow.location.hash || null)
+        ?.replaceWith(...contentDocument.body.children)
     );
   }
 </script>


### PR DESCRIPTION
See #5

**I'm not sure yet about this one** since it's in the scope of the script and not the specific iframe.

I purposefully didn't remove the `frame` parameter of the `htmz` function for now, if there would be some dev cases where it would be desirable, maybe there is none and should also be removed.