### PR TITLE
Fix php_calendar example

### DIFF
--- a/examples/php_calendar/util/persist.php
+++ b/examples/php_calendar/util/persist.php
@@ -1,6 +1,6 @@
 <?php
 function load_calendar() {
-  $cookie = $_COOKIE['calendar'];
+  $cookie = $_COOKIE['calendar'] ?? null;
   if (isset($cookie)) return unserialize(base64_decode($cookie));
   return [];
 }


### PR DESCRIPTION
Very tiny fix where missing index in array throws in PHP unless using null coalescing.

Awesome work btw. Huge fan.