### PR TITLE
swap-template extension

### DIFF
--- a/docs/extensions/index.html
+++ b/docs/extensions/index.html
@@ -185,6 +185,11 @@
             >unwrap-template</a
           >
         </li>
+        <li class="extension-item">
+          <a href="swap-template/" target="extension-demo-frame"
+            >swap-template</a
+          >
+        </li>
       </ul>
 
       <div class="extension-pane">

--- a/docs/extensions/swap-template/add.html
+++ b/docs/extensions/swap-template/add.html
@@ -1,0 +1,21 @@
+<script>
+    const item = new URL(location).searchParams.get("item");
+    const count = parseInt(new URL(location).searchParams.get("count") ?? 0); 
+    document.write(`
+    <template>
+        <li id="item${count}">            
+            ${item}    
+            <a href="delete.html?item=${count}#item${count}" target="htmz">[x]</a>
+        </li>
+        <slot />
+    </template>
+
+    <template id="counter">
+        <input id="counter" type="hidden" name="count" value="${count + 1}">
+    </template>
+
+    <template id="message">
+        <div id="message" style="background: #afa;">Added item #${count}</div>
+    </template>
+  `);
+  </script>

--- a/docs/extensions/swap-template/delete.html
+++ b/docs/extensions/swap-template/delete.html
@@ -1,0 +1,11 @@
+<script>
+    const item = parseInt(new URL(location).searchParams.get("item") ?? 0); 
+    document.write(`
+    <template>
+    </template>
+
+    <template id="message">
+        <div id="message" style="background: #faa;">Deleted item #${item}</div>
+    </template>
+  `);
+  </script>

--- a/docs/extensions/swap-template/index.html
+++ b/docs/extensions/swap-template/index.html
@@ -20,9 +20,10 @@
           const slot = template.content.querySelector("slot");
           
           if(slot) {
-            const copy = target.cloneNode(false);
+            const copy = target.cloneNode();
             target.replaceWith(copy);
             slot.replaceWith.apply(slot, slot.name == "children" ? [...target.children] : [target]);
+            if(slot.children.length) target.replaceChildren(...slot.children);
             target = copy;
           }
           
@@ -47,7 +48,7 @@
 <div id="extension-description">
   <h2>swap-template</h2>
   <p>
-    Sometimes it would be nice to be able to be able to preserve the target element 
+    Sometimes it would be nice to be able to preserve the target element 
     or its children in the DOM tree. This extension allows you to do just that by using HTML
     fragments wrapped in 
     <a
@@ -62,8 +63,10 @@
     ><code>&lt;slot></code></a
     > elements within them.
     <dl>
-      <dt><code>&lt;slot></code></dt> <dd>Represents the original element</dd>
-      <dt><code>&lt;slot name="children"></code></dt> <dd>Represents the original element child nodes</dd>
+      <dt><code>&lt;slot></code></dt> <dd>Represents the original element as is</dd>
+      <dt><code>&lt;slot>...some new content&lt;/slot></code></dt> <dd>Represents the original element 
+        with its children replaced with some new content</dd>
+      <dt><code>&lt;slot name="children"></code></dt> <dd>Represents the original element child nodes</dd>      
     </dl>
   </p>
   <p>

--- a/docs/extensions/swap-template/index.html
+++ b/docs/extensions/swap-template/index.html
@@ -1,0 +1,110 @@
+<div id="extension-code">
+  <script>
+    function htmz(frame) {
+      setTimeout(() => {
+        if (frame.contentWindow.location.href === "about:blank") return;
+
+        // ---------------------------------8<-----------------------------------
+        // Swap <template>
+        // ----------------------------------------------------------------------
+        // This extension swaps standalone top-level <template> tags into target element(s)
+        // optionally allowing to preserve the element itself or its children, or delete the element altogether.  
+
+        frame.contentDocument.querySelectorAll("head>template").forEach(template => {
+          let target = template.id 
+            ? document.getElementById(template.id) 
+            : document.querySelector(frame.contentWindow.location.hash || null);
+          
+          if(!target) return;
+
+          const slot = template.content.querySelector("slot");
+          
+          if(slot) {
+            const copy = target.cloneNode(false);
+            target.replaceWith(copy);
+            slot.replaceWith.apply(slot, slot.name == "children" ? [...target.children] : [target]);
+            target = copy;
+          }
+          
+          if(template.id) 
+            target.replaceWith(template.content); 
+          else 
+            frame.contentDocument.body.append(template.content);
+        });
+        // --------------------------------->8-----------------------------------
+
+        document
+          .querySelector(frame.contentWindow.location.hash || null)
+          ?.replaceWith(...frame.contentDocument.body.children);
+
+        frame.contentWindow.location.replace("about:blank");
+      });
+    }
+  </script>
+  <iframe hidden name="htmz" onload="window.htmz(this)"></iframe>
+</div>
+
+<div id="extension-description">
+  <h2>swap-template</h2>
+  <p>
+    Sometimes it would be nice to be able to be able to preserve the target element 
+    or its children in the DOM tree. This extension allows you to do just that by using HTML
+    fragments wrapped in 
+    <a
+    href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template"
+    target="_blank"
+    ><code>&lt;template></code></a
+    >
+    tags and
+    <a
+    href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot"
+    target="_blank"
+    ><code>&lt;slot></code></a
+    > elements within them.
+    <dl>
+      <dt><code>&lt;slot></code></dt> <dd>Represents the original element</dd>
+      <dt><code>&lt;slot name="children"></code></dt> <dd>Represents the original element child nodes</dd>
+    </dl>
+  </p>
+  <p>
+    Out-of-band multi-target swaps are allowed by setting an <code>id</code> attribute on a <code>&lt;template></code> 
+    element.
+    It is also becomes possible to delete the entire target element by swapping it with an empty <code>&lt;template></code>. 
+  </p>
+  <p>
+    The example below demonstrates a simple editable list implemented using this extension features.
+  </p>
+</div>
+
+<form action="add.html#add" target="htmz">
+  <ul class="items">
+    <li id="add">
+      <input name="item">
+      <button>Add</button>
+    </li>
+  </ul>
+  <input id="counter" type="hidden" name="count" value="1">
+</form>
+
+<div id="message"></div>
+
+<style>
+  #message:not(:empty) {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    margin: 0.5rem;
+    padding: 0.5rem;    
+    animation: alert 0.5s cubic-bezier(0.4, 1.5, 0.4, 1);
+  }
+
+  .items li {
+    margin-bottom: 0.5rem;
+  }
+
+  @keyframes alert {
+    from {
+      transform: scale(0.0001);
+    }
+  }
+</style>


### PR DESCRIPTION
This extension enhances the original `unwrap-template` functionality.

 It is now possible to preserve the original target element or its children anywhere in the replaced DOM part (akin to what's possible with HTMX with `hx-swap` attribute) via strategicaly placed `<slot>` elements. 

Out-of-band updates are now allowed via template's `id` attributes.