### PR TITLE
Enhance: Ignoring Non-2XX Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simply copy the following snippet into your page.
 
 <!-- prettier-ignore-start -->
 ```html
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
 ```
 <!-- prettier-ignore-end -->
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simply copy the following snippet into your page.
 
 <!-- prettier-ignore-start -->
 ```html
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/extensions/loader/index.html
+++ b/docs/extensions/loader/index.html
@@ -10,7 +10,7 @@
         // Wait for destination location for the hash
         setTimeout(() => {
           document
-            .querySelector(frame.contentWindow.location.hash || null)
+            .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
             ?.classList.add("loader");
         });
       });
@@ -18,7 +18,7 @@
 
       setTimeout(() => {
         document
-          .querySelector(frame.contentWindow.location.hash || null)
+          .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
           ?.replaceWith(...frame.contentDocument.body.childNodes);
       });
     }

--- a/docs/extensions/multitarget/index.html
+++ b/docs/extensions/multitarget/index.html
@@ -20,7 +20,7 @@
         // --------------------------------->8-----------------------------------
 
         document
-          .querySelector(frame.contentWindow.location.hash || null)
+          .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
           ?.replaceWith(...frame.contentDocument.body.childNodes);
       });
     }

--- a/docs/extensions/no-history/index.html
+++ b/docs/extensions/no-history/index.html
@@ -11,7 +11,7 @@
       // --------------------------------->8-----------------------------------
       setTimeout(() => {
         document
-          .querySelector(frame.contentWindow.location.hash || null)
+          .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
           ?.replaceWith(...frame.contentDocument.body.childNodes);
         // ---------------------------------8<-----------------------------------
         frame.remove();

--- a/docs/extensions/repeat-gets/index.html
+++ b/docs/extensions/repeat-gets/index.html
@@ -9,7 +9,7 @@
       // --------------------------------->8-----------------------------------
       setTimeout(() => {
         document
-          .querySelector(frame.contentWindow.location.hash || null)
+          .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
           ?.replaceWith(...frame.contentDocument.body.childNodes);
         // ---------------------------------8<-----------------------------------
         frame.contentWindow.location.replace("about:blank");

--- a/docs/extensions/swap-template/index.html
+++ b/docs/extensions/swap-template/index.html
@@ -11,7 +11,7 @@
         // optionally allowing to preserve the element itself or its children, or delete the element altogether.  
 
         frame.contentDocument.querySelectorAll("head>template").forEach(template => {
-          let target = document.querySelector(frame.contentWindow.location.hash || null);
+          let target = document.querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null);
           
           if(!target) return;
 
@@ -37,7 +37,7 @@
         // --------------------------------->8-----------------------------------
 
         document
-          .querySelector(frame.contentWindow.location.hash || null)
+          .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
           ?.replaceWith(...frame.contentDocument.body.childNodes);
 
         frame.contentWindow.location.replace("about:blank");

--- a/docs/extensions/unwrap-template/index.html
+++ b/docs/extensions/unwrap-template/index.html
@@ -14,7 +14,7 @@
         // --------------------------------->8-----------------------------------
 
         document
-          .querySelector(frame.contentWindow.location.hash || null)
+          .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
           ?.replaceWith(...frame.contentDocument.body.childNodes);
       });
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@
     </div>
 
     <!-- prettier-ignore -->
-    <iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+    <iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
 
     <script defer src="footer.js"></script>
     <script

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@
     </div>
 
     <!-- prettier-ignore -->
-    <iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+    <iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
 
     <script defer src="footer.js"></script>
     <script

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       <div>
         <h2>lightweight<span class="heading-icon">🪶</span></h2>
         <p>
-          <strong>166 bytes in total.</strong> Zero dependencies. Zero JS
+          <strong>253 bytes in total.</strong> Zero dependencies. Zero JS
           bundles to load. Not even a backend is required.
           <em>Just an inline HTML snippet</em>.
         </p>
@@ -119,7 +119,7 @@
       <p>Simply copy the following snippet into your page:</p>
       <pre
         class="code"
-      ><code class="rainbow-mask">&lt;iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))">&lt;/iframe></code></pre>
+      ><code class="rainbow-mask">&lt;iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))">&lt;/iframe></code></pre>
       <p>
         For <strong>npm enjoyers</strong>, use the following npm commands to
         automate the <em>simple process of copying the snippet</em>. For maximum

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,9 @@
 -->&lt;<span class="code-token">iframe hidden name</span>="<b>#my-element</b>" <span class="code-token">onload</span>="htmz(<span class="code-token">this</span>)">&lt;/<span class="code-token">iframe</span>>
 &lt;<span class="code-token">script</span>>
   <span class="code-token">function</span> htmz(frame) {
+
+    if(!/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus)) return;
+
     document.<span class="code-token">querySelector</span>(frame.name) <span class="code-comment">// use the iframe's name instead of the URL hash</span>
       ?.<span class="code-token">replaceWith</span>(...frame.contentDocument.body.childNodes);
   }
@@ -401,7 +404,7 @@
     <span class="code-comment">// Remove setTimeout to let the browser autoscroll content changes into view</span>
     <span class="code-token">setTimeout</span>(() =>
       document
-        .<span class="code-token">querySelector</span>(frame.contentWindow.location.hash || <span class="code-token">null</span>)
+        .<span class="code-token">querySelector</span>(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || <span class="code-token">null</span>)
         ?.<span class="code-token">replaceWith</span>(...frame.contentDocument.body.childNodes)
     );
   }

--- a/examples/cf_clean_target_tabs/index.html
+++ b/examples/cf_clean_target_tabs/index.html
@@ -18,7 +18,7 @@
 
 <script>
   function htmz(frame) {
-    if (frame.contentWindow.location.href === "about:blank") return;
+    if (frame.contentWindow.location.href === "about:blank" || !/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus)) return;
     const duplicates = document.getElementsByName(frame.name);
 
     document

--- a/examples/html_clean_target_tabs/index.html
+++ b/examples/html_clean_target_tabs/index.html
@@ -19,6 +19,9 @@
 
 <script>
   function htmz(frame) {
+
+    if(!/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus)) return;
+
     document
       .querySelector(frame.name) // use the iframe's name instead of the URL hash
       ?.replaceWith(...frame.contentDocument.body.childNodes);

--- a/examples/html_tabs/index.html
+++ b/examples/html_tabs/index.html
@@ -17,4 +17,4 @@
 
 <div id="my-tab-panel" role="tabpanel"></div>
 
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>

--- a/examples/html_tabs/index.html
+++ b/examples/html_tabs/index.html
@@ -17,4 +17,4 @@
 
 <div id="my-tab-panel" role="tabpanel"></div>
 
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>

--- a/examples/js_simple_error_handling/index.html
+++ b/examples/js_simple_error_handling/index.html
@@ -37,7 +37,7 @@
 
     setTimeout(() =>
       document
-        .querySelector(frame.contentWindow.location.hash || null)
+        .querySelector(/^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash || null)
         ?.replaceWith(...frame.contentDocument.body.childNodes)
     );
   }

--- a/examples/node_chat/index.html
+++ b/examples/node_chat/index.html
@@ -29,7 +29,7 @@
 </form>
 
 <!-- prettier-ignore -->
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
 
 <style>
   body {

--- a/examples/node_chat/index.html
+++ b/examples/node_chat/index.html
@@ -29,7 +29,7 @@
 </form>
 
 <!-- prettier-ignore -->
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
 
 <style>
   body {

--- a/htmz.dev.html
+++ b/htmz.dev.html
@@ -7,7 +7,7 @@
     // Remove setTimeout wrapper to allow automatic scrolling.
     setTimeout(() =>
       document.querySelector(
-        (frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus + "").startsWith(2) && frame.contentWindow.location.hash
+        /^2/.test(frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus) && frame.contentWindow.location.hash
         || null
       )?.replaceWith(...frame.contentDocument.body.childNodes)
     );

--- a/htmz.dev.html
+++ b/htmz.dev.html
@@ -6,9 +6,10 @@
     // This delay prevents that, making this is the only case where we don't lean on browser defaults.
     // Remove setTimeout wrapper to allow automatic scrolling.
     setTimeout(() =>
-      document
-        .querySelector(frame.contentWindow.location.hash || null)
-        ?.replaceWith(...frame.contentDocument.body.childNodes)
+      document.querySelector(
+        (frame.contentWindow.performance.getEntriesByType("navigation")[0].responseStatus + "").startsWith(2) && frame.contentWindow.location.hash
+        || null
+      )?.replaceWith(...frame.contentDocument.body.childNodes)
     );
   }
 </script>

--- a/htmz.html
+++ b/htmz.html
@@ -1,1 +1,1 @@
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>

--- a/htmz.html
+++ b/htmz.html
@@ -1,1 +1,1 @@
-<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>
+<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>

--- a/npx/index.js
+++ b/npx/index.js
@@ -5,7 +5,7 @@ import { hideBin } from "yargs/helpers";
 import { RewritingStream } from 'parse5-html-rewriting-stream';
 import ss from "stream-string";
 
-const snippetHolder = [`<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>`];
+const snippetHolder = [`<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>`];
 
 const args = yargs(hideBin(process.argv))
   .scriptName("npx htmzify")

--- a/npx/index.js
+++ b/npx/index.js
@@ -5,7 +5,7 @@ import { hideBin } from "yargs/helpers";
 import { RewritingStream } from 'parse5-html-rewriting-stream';
 import ss from "stream-string";
 
-const snippetHolder = [`<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector((contentWindow.performance.getEntriesByType('navigation')[0].responseStatus+'').startsWith(2)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>`];
+const snippetHolder = [`<iframe hidden name=htmz onload="setTimeout(()=>document.querySelector(/^2/.test(contentWindow.performance.getEntriesByType('navigation')[0].responseStatus)&&contentWindow.location.hash||null)?.replaceWith(...contentDocument.body.childNodes))"></iframe>`];
 
 const args = yargs(hideBin(process.argv))
   .scriptName("npx htmzify")


### PR DESCRIPTION
# Existing Problem
+ HTMZ renders any response, whether it is from 4XX or 5XX

# Solution
+ Adding self-validation of status code
  + Render only if the status code is 2XX

# Disadvantage
+ Code size increases up to 52% (166 bytes -> 253 bytes)
+ Currently unavailable only on Safari (bc it depends on [`PerformanceNavigationTiming.responseStatus`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus#browser_compatibility))